### PR TITLE
[F] Update preisatlas profiles

### DIFF
--- a/_profiles/preisatlas-test.html
+++ b/_profiles/preisatlas-test.html
@@ -3,7 +3,7 @@
 # The human-friendly name of the profile. Whenever you're asked for the profile
 # ID, it refers to the name of the profile file — in this case, "default".
 #
-name: "Preisatlas Staging"
+name: "Preisatlas Test"
 
 #
 # The default profile will be the one shown when accessing the root URL of your
@@ -29,7 +29,7 @@ parameters:
   location: "ec2-eu-central-1:Chrome"
   firstViewOnly: true
   runs: 3
-  url: "http://pe.staging.homeday.de/de/preisatlas/berlin/grellstra%C3%9Fe,+prenzlauer+berg+10409?map_layer=standard&property_type=apartment"
+  url: "http://pe-test.homeday.de/de/preisatlas/berlin/grellstra%C3%9Fe,+prenzlauer+berg+10409?map_layer=standard&property_type=apartment"
 
 #
 # The URL of the WebPageTest instance to be used with this profile. Please note that

--- a/_profiles/preisatlas.html
+++ b/_profiles/preisatlas.html
@@ -29,7 +29,7 @@ parameters:
   location: "ec2-eu-central-1:Chrome"
   firstViewOnly: true
   runs: 3
-  url: "https://www.homeday.de/preisatlas/de-DE/berlin/grellstra%C3%9Fe,+prenzlauer+berg+10409?map_layer=standard&property_type=apartment"
+  url: "https://www.homeday.de/de/preisatlas/berlin/grellstra%C3%9Fe,+prenzlauer+berg+10409?map_layer=standard&property_type=apartment"
 
 #
 # The URL of the WebPageTest instance to be used with this profile. Please note that


### PR DESCRIPTION
Added preisatlas test config. 
Additionally updated urls to respond to latest structure and use same protocol and test profiles, to make sure comparison is relevant. 

@viniciuskneves: This is how you can add profiles. 
The intervals are set in the profile, but you can also trigger the test manually, through this: https://speedtracker.org/test